### PR TITLE
Race conditions exists in Agent::Transport::Queue

### DIFF
--- a/lib/agent/transport/queue.rb
+++ b/lib/agent/transport/queue.rb
@@ -2,11 +2,11 @@ module Agent
   module Transport
 
     class MemoryQueue
-      attr_accessor :que, :wait, :monitor, :cvar
+      attr_accessor :que, :monitor, :cvar
       def initialize
-        @que, @wait = [], []
+        @que     = []
         @monitor = Monitor.new
-        @cvar = @monitor.new_cond
+        @cvar    = @monitor.new_cond
       end
     end
 
@@ -30,7 +30,7 @@ module Agent
         Queue.register(name)
       end
 
-      %w[que wait monitor cvar].each do |attr|
+      %w[que monitor cvar].each do |attr|
         define_method attr do
           begin
             Queue.send(:class_variable_get, :"@@__agent_queue_#{@name}__").send attr


### PR DESCRIPTION
The contents of `que` could change between the lines checking their contents ([L85](https://github.com/igrigorik/agent/blob/master/lib/agent/transport/queue.rb#L85) and [L90](https://github.com/igrigorik/agent/blob/master/lib/agent/transport/queue.rb#L90)), and when pop or push synchronizes to to prevent modification to `que` ([L52](https://github.com/igrigorik/agent/blob/master/lib/agent/transport/queue.rb#L52) and [L67](https://github.com/igrigorik/agent/blob/master/lib/agent/transport/queue.rb#L67)). This could cause a call to receive(true) or send(msg, true) to block instead of raising an exception.

To fix this, this patch changes the mutex to a monitor, which I think is more appropriate for two reasons. The first is that we're waiting until a statement is true, so MonitorMixin::ConditionVariable's handy wait_while method is a good fit and simplifies the code. The second is that Monitors are re-entrant, which lets us synchronize both in receive and pop (or send and push) which should prevent the race condition mentioned above while keeping receive/send and pop/push separate.

The specs all pass in ruby 1.9.2-p290 and 1.9.3-p125, and jruby 1.6.7 in 1.9 mode.
