### PR TITLE
Let travis use most recent Ruby 2.X versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 2.1.0
-  - 2.0.0
+  - 2.1
+  - 2.0
   - 1.9.3
   - 1.9.2
   - jruby-18mode


### PR DESCRIPTION
Currently Travis uses Ruby [2.1.0p0](https://travis-ci.org/igrigorik/agent/jobs/17870376#L16) which is not the most recent version of Ruby in the 2.1 branch.

This PR allows Travis to use the most recent 2.X Ruby version.
