### PR TITLE
Corrects the behaviour of select for closed channels

### DIFF
--- a/lib/agent/channel.rb
+++ b/lib/agent/channel.rb
@@ -61,8 +61,10 @@ module Agent
     def receive(options={})
       check_direction(:receive)
       q = queue
-      return [nil, false] unless q
-      q.pop(options)
+      return q.pop(options) if q
+      pop = Pop.new(options)
+      pop.close
+      return [pop.object, false]
     end
     alias :pop  :receive
 

--- a/lib/agent/channel.rb
+++ b/lib/agent/channel.rb
@@ -64,7 +64,7 @@ module Agent
       return q.pop(options) if q
       pop = Pop.new(options)
       pop.close
-      return [pop.object, false]
+      [pop.object, false]
     end
     alias :pop  :receive
 

--- a/spec/selector_spec.rb
+++ b/spec/selector_spec.rb
@@ -108,6 +108,19 @@ describe Agent::Selector do
       expect(r.first).to eq(:default)
     end
 
+    it "should evaluate a matching prior closed channel in preference to the default case" do
+      r = []
+
+      @c.close
+      select! do |s|
+        s.case(@c, :receive) { r.push :from_closed }
+        s.default { r.push :default }
+      end
+
+      expect(r.size).to eq(1)
+      expect(r.first).to eq(:from_closed)
+    end
+
     it "should raise an error if the channel is closed out from under it and you are sending to it" do
       go!{ sleep 0.25; @c.close }
 
@@ -298,6 +311,20 @@ describe Agent::Selector do
 
       expect(r.size).to eq(1)
       expect(r.first).to eq(:default)
+    end
+
+    it "should evaluate a matching prior closed channel in preference to the default case" do
+      r = []
+
+      @c.close
+
+      select! do |s|
+        s.case(@c, :receive) { r.push :from_closed }
+        s.default { r.push :default }
+      end
+
+      expect(r.size).to eq(1)
+      expect(r.first).to eq(:from_closed)
     end
 
     it "should raise an error if the channel is closed out from under it and you are sending to it" do


### PR DESCRIPTION
This is follow-up to the work on closed channels in #20.

#21 did not have a test to check that select successfully picks channels that on receiving, select is fired by channels that have already been closed

@nate, please take a look.